### PR TITLE
Add groups configuration to show specific groups only

### DIFF
--- a/README
+++ b/README
@@ -28,6 +28,15 @@ INSTALLATION
 
 CONFIGURATION
 
+    By default, all privilegued users are shown. There is a known problem
+    with users which don't own any tickets being hidden.
+
+    If you want to show specific groups, you can configure an array of group names:
+
+        Set($UserSearch_Groups,
+        [ "development" ]
+        );
+
     Navigate into Admin - Global - Group Rights and select the group to modify.
     Select the Rights for staff tab and tick Show the usersearch box.
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,23 @@ Restart your webserver.
 
 ## Configuration
 
+By default, all privilegued users are shown. There is a known problem
+with users which don't own any tickets being hidden.
+
+If you want to show specific groups, you can configure an array of group names:
+
+```
+Set($UserSearch_Groups,
+[ "development" ]
+);
+```
+
+### Permissions
+
 Navigate into `Admin` - `Global` - `Group Rights` and select the group to modify.
 Select the `Rights for staff` tab and tick `Show the usersearch box`.
+
+### Dashboard
 
 Users need to edit their dashboard and add the `RT-Extension-UserSearch` droplet.
 

--- a/html/Elements/RT-Extension-UserSearch
+++ b/html/Elements/RT-Extension-UserSearch
@@ -3,13 +3,36 @@
 </&>
 <%init>
 
-	unless ( $session{'CurrentUser'}->HasRight( Object => RT->System, Right => 'ShowUserSearch' ) ) {
-		return;
-	}
+unless ($session{'CurrentUser'}->HasRight( Object => RT->System, Right => 'ShowUserSearch')) {
+  return;
+}
 
-	my $Users = RT::Users->new(RT->SystemUser);
-	$Users->LimitToPrivileged();
-	my @StatusList = qw(new open stalled);
+my @StatusList = qw(new open stalled);
+
+my $usc = RT->Config->Get('UserSearch_Groups');
+
+my $Users = RT::Users->new(RT->SystemUser);
+my $systemUser  = RT::User->new($RT::SystemUser);
+
+if ($usc) {
+  my $groups;
+
+  for my $userGroupName (@{$usc}) {
+    my $groupObj = new RT::Group($systemUser);
+    $groupObj->LoadUserDefinedGroup($userGroupName);
+
+    if (not $groupObj->Id) {
+      RT::Logger->crit("UserSearch configuration error: Group ". $userGroupName . " not found in RT.");
+      next;
+    }
+
+    push @{$groups}, $groupObj->Id;
+  }
+
+  $Users->WhoBelongToGroups(Groups => $groups, IncludeSubgroupMembers => 1, IncludeUnprivileged => 1);
+} else {
+  $Users->LimitToPrivileged();
+}
 
 </%init>
 <%args>


### PR DESCRIPTION
LimitToPrivilegued() doesn't show users which have been created
since 4.4.3 if they don't own any tickets. With the specific
group configuration, this is circumvented and allows for a more
fine granular listing.